### PR TITLE
Fix ESLint errors to enable Vercel deployment

### DIFF
--- a/src/app/(rooms)/final-room/page.tsx
+++ b/src/app/(rooms)/final-room/page.tsx
@@ -36,7 +36,7 @@ const finalQuizQuestions: Question[] = [
 ];
 
 const FinalRoomPage: React.FC = () => {
-  const { isRoomUnlocked, stopAllSounds: stopGameSounds } = useGameContext(); // Assuming stopAllSounds might be added to context
+  const { isRoomUnlocked } = useGameContext(); // Assuming stopAllSounds might be added to context
   const router = useRouter();
   const { playSound, stopSound: stopBackgroundHum } = useSound(); // For specific sounds in this room
   const [isLabEscaped, setIsLabEscaped] = useState(false);

--- a/src/app/(rooms)/room1/page.tsx
+++ b/src/app/(rooms)/room1/page.tsx
@@ -8,7 +8,6 @@ import PuzzlePlaceholder from '@/components/PuzzlePlaceholder/PuzzlePlaceholder'
 import Clue from '@/components/Clue/Clue';
 import OhmsLawQuiz from '@/components/OhmsLawQuiz/OhmsLawQuiz';
 import { useGameContext } from '@/context/GameContext';
-import useSound from '@/hooks/useSound'; // Import useSound
 
 const Room1Page: React.FC = () => {
   const { unlockRoom2 } = useGameContext();

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation'; // To highlight active link
 import { useGameContext } from '@/context/GameContext';
 
 const Header: React.FC = () => {
-  const { unlockedRooms, isRoomUnlocked } = useGameContext();
+  const { isRoomUnlocked } = useGameContext();
   const pathname = usePathname();
 
   const navLinkClasses = (path: string, isEnabled: boolean) =>

--- a/src/components/OhmsLawQuiz/OhmsLawQuiz.tsx
+++ b/src/components/OhmsLawQuiz/OhmsLawQuiz.tsx
@@ -30,7 +30,7 @@ const OhmsLawQuiz: React.FC<OhmsLawQuizProps> = ({ voltage, resistance, onSolve 
     } else {
       playSound('incorrect.mp3');
       setFeedbackMessage(
-        `Not quite! Remember Ohm's Law: Current (I) = Voltage (V) / Resistance (R).
+        `Not quite! Remember Ohm&apos;s Law: Current (I) = Voltage (V) / Resistance (R).
          With V=${voltage}V and R=${resistance}Ω, the current should be ${expectedCurrent.toFixed(2)}A.
          You entered ${userAnswerNumeric}A. Try calculating again.`
       );


### PR DESCRIPTION
This commit addresses several ESLint issues that were causing the Vercel build to fail:

- Removed unused `stopGameSounds` variable in `src/app/(rooms)/final-room/page.tsx`.
- Removed unused `useSound` import in `src/app/(rooms)/room1/page.tsx`.
- Removed unused `unlockedRooms` variable in `src/components/Header/Header.tsx`.
- Fixed `no-unescaped-entities` error by replacing an apostrophe with `&apos;` in `src/components/OhmsLawQuiz/OhmsLawQuiz.tsx`.

These changes should allow the Next.js application to build successfully on Vercel.