### PR TITLE
Fix: Handle potential null in CircuitDnDQuiz component

### DIFF
--- a/src/components/CircuitDnDQuiz/CircuitDnDQuiz.tsx
+++ b/src/components/CircuitDnDQuiz/CircuitDnDQuiz.tsx
@@ -121,7 +121,7 @@ const CircuitDnDQuiz: React.FC<CircuitDnDQuizProps> = ({ onSolve }) => {
                 >
                   <p className="text-[10px] sm:text-xs text-gray-500 capitalize mb-1">{slot.requiredType} Slot</p>
                   {slot.placedComponent ? (
-                    <Draggable draggableId={slot.placedComponent.id} index={index} key={slot.placedComponent.id}>
+                    <Draggable draggableId={slot.placedComponent?.id!} index={index} key={slot.placedComponent?.id!}>
                       {(dragProvided) => (
                         <div
                           ref={dragProvided.innerRef}
@@ -129,7 +129,7 @@ const CircuitDnDQuiz: React.FC<CircuitDnDQuizProps> = ({ onSolve }) => {
                           {...dragProvided.dragHandleProps}
                           className="p-1 sm:p-2 bg-white rounded shadow border border-gray-300 text-xs sm:text-sm"
                         >
-                          {slot.placedComponent.name}
+                          {slot.placedComponent?.name}
                         </div>
                       )}
                     </Draggable>


### PR DESCRIPTION
Addresses a TypeScript error during Vercel deployment: `Type error: 'slot.placedComponent' is possibly 'null'.`

The error occurred in `src/components/CircuitDnDQuiz/CircuitDnDQuiz.tsx` when accessing `slot.placedComponent.name` and `slot.placedComponent.id`.

This commit fixes the issue by:
- Using optional chaining (`?.`) for `slot.placedComponent.name`.
- Using non-null assertion (`!`) for `slot.placedComponent.id` within the `Draggable` component's props, as the component's rendering is already conditional on `slot.placedComponent` being non-null.

This ensures safer property access and resolves the build failure.